### PR TITLE
Add admin options for default translation languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-# polylang-deepl-cli
+# Polylang DeepL CLI
+
+WP-CLI commands for translating WooCommerce content via DeepL and Polylang.
+
+Default languages for commands can be configured in the WordPress admin menu
+under **Languages → Auto translate**.

--- a/commands/Translate-Posts-Command.php
+++ b/commands/Translate-Posts-Command.php
@@ -9,7 +9,7 @@ WP_CLI::add_command('translate-post', function ($args) {
     }
 
     $lang_from = pll_get_post_language($post_id);
-    $lang_to = PLL_DEEPL_LANG_TO;
+    $lang_to   = pll_deepl_get_lang_to();
 
     if (!$lang_from || $lang_from === $lang_to) {
         WP_CLI::error("Исходный язык не определён или совпадает с целевым.");
@@ -168,12 +168,12 @@ WP_CLI::add_command('translate-post', function ($args) {
 });
 
 WP_CLI::add_command('translate-all-products', function () {
-    $lang_to = PLL_DEEPL_LANG_TO;
+    $lang_to = pll_deepl_get_lang_to();
     $products = get_posts([
         'post_type'      => 'product',
         'posts_per_page' => -1,
         'post_status'    => 'publish',
-        'lang'           => PLL_DEEPL_LANG_FROM
+        'lang'           => pll_deepl_get_lang_from()
     ]);
 
     foreach ($products as $product) {

--- a/commands/Translate_Attribute_Command.php
+++ b/commands/Translate_Attribute_Command.php
@@ -42,7 +42,7 @@ function translate_attribute_terms_by_taxonomy($taxonomy) {
         return;
     }
 
-    $lang_to = PLL_DEEPL_LANG_TO;
+    $lang_to = pll_deepl_get_lang_to();
     $log_file = WP_CONTENT_DIR . '/translation-skipped.log';
 
     foreach ($terms as $term) {

--- a/commands/Translate_Attribute_Term_Command.php
+++ b/commands/Translate_Attribute_Term_Command.php
@@ -13,7 +13,7 @@ WP_CLI::add_command('translate-attribute-term', function ($args) {
     }
 
     $lang_from = pll_get_term_language($term_id);
-    $lang_to   = PLL_DEEPL_LANG_TO;
+    $lang_to   = pll_deepl_get_lang_to();
 
     ensure_language_exists($lang_from);
     ensure_language_exists($lang_to);

--- a/commands/Translate_Menu_Command.php
+++ b/commands/Translate_Menu_Command.php
@@ -2,8 +2,8 @@
 
 WP_CLI::add_command('translate-menu', function ($args) {
     $menu_id   = 8;
-    $lang_from = PLL_DEEPL_LANG_FROM;
-    $lang_to   = PLL_DEEPL_LANG_TO;
+    $lang_from = pll_deepl_get_lang_from();
+    $lang_to   = pll_deepl_get_lang_to();
 
     $menu = wp_get_nav_menu_object($menu_id);
     if (!$menu) {

--- a/commands/Translate_Page_Command.php
+++ b/commands/Translate_Page_Command.php
@@ -6,8 +6,8 @@ if (defined('WP_CLI') && WP_CLI) {
 class Translate_Page_Command {
     public function __invoke($args, $assoc_args) {
         list($post_id) = $args;
-        $lang_from = PLL_DEEPL_LANG_FROM;
-        $lang_to   = PLL_DEEPL_LANG_TO;
+        $lang_from = pll_deepl_get_lang_from();
+        $lang_to   = pll_deepl_get_lang_to();
 
         $post = get_post($post_id);
 

--- a/commands/Translate_Taxonomies_Command.php
+++ b/commands/Translate_Taxonomies_Command.php
@@ -22,8 +22,8 @@ class Translate_Taxonomy_By_ID_Command {
      */
     public function __invoke($args, $assoc_args) {
         list($term_id) = $args;
-        $lang_from = PLL_DEEPL_LANG_FROM;
-        $lang_to   = PLL_DEEPL_LANG_TO;
+        $lang_from = pll_deepl_get_lang_from();
+        $lang_to   = pll_deepl_get_lang_to();
 
         $term = get_term($term_id);
         if (!$term || is_wp_error($term)) {
@@ -77,8 +77,8 @@ class Translate_All_Taxonomies_Command {
      * wp translate-all-taxonomies --lang_from=uk --lang_to=en
      */
     public function __invoke($args, $assoc_args) {
-        $lang_from = PLL_DEEPL_LANG_FROM;
-        $lang_to   = PLL_DEEPL_LANG_TO;
+        $lang_from = pll_deepl_get_lang_from();
+        $lang_to   = pll_deepl_get_lang_to();
 
         $taxonomies = get_taxonomies([], 'names');
         foreach ($taxonomies as $taxonomy) {

--- a/commands/Translate_Term_Command.php
+++ b/commands/Translate_Term_Command.php
@@ -1,6 +1,7 @@
 <?php
 
-function translate_single_category_term($term, $lang_to = PLL_DEEPL_LANG_TO) {
+function translate_single_category_term($term, $lang_to = null) {
+    $lang_to = $lang_to ?: pll_deepl_get_lang_to();
     $taxonomy = 'product_cat';
     $lang_from = pll_get_term_language($term->term_id);
 

--- a/polylang-deepl-cli.php
+++ b/polylang-deepl-cli.php
@@ -13,6 +13,62 @@ if (!defined('PLL_DEEPL_LANG_TO')) {
     define('PLL_DEEPL_LANG_TO', 'en');
 }
 
+/**
+ * Получить код исходного языка.
+ * Приоритет: опция WordPress -> константа.
+ */
+function pll_deepl_get_lang_from() {
+    $opt = get_option('pll_deepl_lang_from');
+    return $opt ? $opt : PLL_DEEPL_LANG_FROM;
+}
+
+/**
+ * Получить код языка перевода.
+ * Приоритет: опция WordPress -> константа.
+ */
+function pll_deepl_get_lang_to() {
+    $opt = get_option('pll_deepl_lang_to');
+    return $opt ? $opt : PLL_DEEPL_LANG_TO;
+}
+
+add_action('admin_init', 'pll_deepl_register_settings');
+function pll_deepl_register_settings() {
+    register_setting('pll_deepl_settings', 'pll_deepl_lang_from');
+    register_setting('pll_deepl_settings', 'pll_deepl_lang_to');
+}
+
+add_action('admin_menu', 'pll_deepl_add_admin_page');
+function pll_deepl_add_admin_page() {
+    add_submenu_page(
+        'pll_languages',
+        'Auto translate',
+        'Auto translate',
+        'manage_options',
+        'pll-deepl-auto',
+        'pll_deepl_render_page'
+    );
+}
+
+function pll_deepl_render_page() { ?>
+    <div class="wrap">
+        <h1><?php esc_html_e('Auto translate', 'polylang-deepl-cli'); ?></h1>
+        <form method="post" action="options.php">
+            <?php settings_fields('pll_deepl_settings'); ?>
+            <table class="form-table" role="presentation">
+                <tr>
+                    <th scope="row"><label for="pll_deepl_lang_from"><?php esc_html_e('Translate from', 'polylang-deepl-cli'); ?></label></th>
+                    <td><input name="pll_deepl_lang_from" id="pll_deepl_lang_from" type="text" value="<?php echo esc_attr( get_option('pll_deepl_lang_from', PLL_DEEPL_LANG_FROM) ); ?>" class="regular-text" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="pll_deepl_lang_to"><?php esc_html_e('Translate to', 'polylang-deepl-cli'); ?></label></th>
+                    <td><input name="pll_deepl_lang_to" id="pll_deepl_lang_to" type="text" value="<?php echo esc_attr( get_option('pll_deepl_lang_to', PLL_DEEPL_LANG_TO) ); ?>" class="regular-text" /></td>
+                </tr>
+            </table>
+            <?php submit_button(); ?>
+        </form>
+    </div>
+<?php }
+
 function translate_preserving_tags($html, $lang_from, $lang_to) {
     $doc = new DOMDocument();
     libxml_use_internal_errors(true);

--- a/readme.txt
+++ b/readme.txt
@@ -37,8 +37,9 @@ WP-CLI команды для перевода товаров, категорий
 1. Скопируйте папку плагина `polylang-deepl-cli` в `/wp-content/plugins/`
 2. Активируйте плагин через админку WordPress
 3. Убедитесь, что в Polylang настроен API-ключ DeepL (`pll_settings['machine_translation_services']['deepl']['api_key']`)
-4. Вставьте API-ключ DeepL в $key основного файла плагина
-5. Используйте WP-CLI команды:
+4. Настройте исходный и целевой языки в меню «Языки → Auto translate»
+5. Вставьте API-ключ DeepL в $key основного файла плагина
+6. Используйте WP-CLI команды:
 
 wp translate-post 123
 wp translate-term 456


### PR DESCRIPTION
## Summary
- add helper functions to fetch language options
- register settings and create "Auto translate" submenu
- implement settings page with source/target fields
- use new helpers in WP-CLI commands
- document new submenu

## Testing
- `php -l polylang-deepl-cli.php`
- `php -l commands/Translate_Attribute_Term_Command.php`
- `php -l commands/Translate_Attribute_Command.php`
- `php -l commands/Translate-Posts-Command.php`
- `php -l commands/Translate_Menu_Command.php`
- `php -l commands/Translate_Page_Command.php`
- `php -l commands/Translate_Taxonomies_Command.php`
- `php -l commands/Translate_Term_Command.php`

------
https://chatgpt.com/codex/tasks/task_e_6876466e7608833380595fbf71a3386b