### PR TITLE
Remove closing PHP tag

### DIFF
--- a/commands/Translate_Custom_Post_Command.php
+++ b/commands/Translate_Custom_Post_Command.php
@@ -86,4 +86,3 @@ class Translate_Custom_Post_Command {
         WP_CLI::success("Все записи типа {$post_type} переведены.");
     }
 }
-?>


### PR DESCRIPTION
## Summary
- clean up `Translate_Custom_Post_Command.php` by removing the closing `?>`

## Testing
- `php -l commands/Translate_Custom_Post_Command.php`


------
https://chatgpt.com/codex/tasks/task_e_68766ff11bcc8333bb5369bf17238501